### PR TITLE
Route admins to dashboard on login

### DIFF
--- a/pages/admin.js
+++ b/pages/admin.js
@@ -26,6 +26,14 @@ export default function Admin(){
     <div className="wrap">
       <div className="card" style={{textAlign:'left'}}>
         <h1>Admin</h1>
+        <button
+          type="button"
+          className="primary"
+          style={{ marginBottom: '1rem' }}
+          onClick={() => { window.location.href = '/puzzle1'; }}
+        >
+          Go to Puzzle
+        </button>
         {err && <div className="feedback">⚠️ {err}</div>}
         <h3>Progress</h3>
         <pre className="small">{JSON.stringify(rows,null,2)}</pre>

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,8 +7,12 @@ export default function Home(){
   const [err, setErr] = useState('');
 
   useEffect(()=>{
-    supabase.auth.getSession().then(({data:{session}})=>{
-      if(session) window.location.href = '/puzzle1';
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if(!session) return;
+      const destination = session.user?.email === process.env.NEXT_PUBLIC_ADMIN_EMAIL
+        ? '/admin'
+        : '/puzzle1';
+      window.location.href = destination;
     });
   }, []);
 
@@ -17,7 +21,10 @@ export default function Home(){
     setErr('');
     const { data, error } = await supabase.auth.signInWithPassword({ email, password });
     if(error){ setErr(error.message); return; }
-    window.location.href = '/puzzle1';
+    const destination = data.user?.email === process.env.NEXT_PUBLIC_ADMIN_EMAIL
+      ? '/admin'
+      : '/puzzle1';
+    window.location.href = destination;
   }
 
   return (


### PR DESCRIPTION
## Summary
- redirect authenticated admins to the admin dashboard when loading the landing page
- send newly signed-in admins to the admin dashboard instead of the first puzzle
- keep existing puzzle redirect for non-admin users

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0cf0955cc8322a245c1a429ad53c1