### PR TITLE
Add subtle audio download icon to Puzzle 3

### DIFF
--- a/pages/puzzle3.js
+++ b/pages/puzzle3.js
@@ -30,7 +30,18 @@ export default function Puzzle(){
   return (
     <div className="wrap">
       <div className="card">
-        <audio controls src="/convert.ing-now________SPECTOGRAM.wav" controlsList="download"></audio><p className="small">.</p>
+        <div className="audio-wrap">
+          <audio controls src="/convert.ing-now________SPECTOGRAM.wav" controlsList="download"></audio>
+          <a
+            className="audio-download"
+            href="/convert.ing-now________SPECTOGRAM.wav"
+            download
+            aria-label="Download audio"
+          >
+            <span aria-hidden="true">⇩</span>
+          </a>
+        </div>
+        <p className="small">.</p>
         <div className="answer">
           <input id="ans" placeholder="Answer" value={ans} onChange={e=>setAns(e.target.value)} maxlength="2"/>
           <button id="go" onClick={submit}>Submit</button>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -14,4 +14,7 @@ h1{color:var(--accent);margin:0 0 10px;}
   border:1px solid rgba(255,255,255,0.14);border-radius:10px;font-size:16px;text-align:center;}
 .feedback{margin-top:10px;font-size:13px;color:var(--muted);} 
 img, audio{max-width:100%;border-radius:8px;}
+.audio-wrap{display:flex;align-items:center;justify-content:center;gap:8px;margin-bottom:4px;}
+.audio-download{color:var(--muted);text-decoration:none;font-size:20px;line-height:1;opacity:0.6;padding:4px;border-radius:6px;display:inline-flex;align-items:center;}
+.audio-download:focus,.audio-download:hover{opacity:1;background:rgba(255,255,255,0.08);}
 .small{font-size:12px;color:var(--muted);}


### PR DESCRIPTION
## Summary
- wrap the Puzzle 3 audio player with a subtle download control for easier access on mobile
- style the download icon to remain unobtrusive while supporting hover and focus feedback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e14e1973ac83229f527577b7089bf8