### PR TITLE
Restore download icon on Puzzle 3 audio player

### DIFF
--- a/pages/puzzle3.js
+++ b/pages/puzzle3.js
@@ -30,7 +30,35 @@ export default function Puzzle(){
   return (
     <div className="wrap">
       <div className="card">
-        <audio controls src="/convert.ing-now________SPECTOGRAM.wav" controlsList="download"></audio><p className="small">.</p>
+        <div className="audio-wrap">
+          <audio controls src="/convert.ing-now________SPECTOGRAM.wav" controlsList="download"></audio>
+          <a
+            className="audio-download"
+            href="/convert.ing-now________SPECTOGRAM.wav"
+            download
+            aria-label="Download audio"
+            title="Download audio"
+          >
+            <svg
+              aria-hidden="true"
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 4v9m0 0 3-3m-3 3-3-3m9 7H9m9 0h-3m-6 0H6"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            <span className="sr-only">Download audio file</span>
+          </a>
+        </div>
+        <p className="small">.</p>
         <div className="answer">
           <input id="ans" placeholder="Answer" value={ans} onChange={e=>setAns(e.target.value)} maxlength="2"/>
           <button id="go" onClick={submit}>Submit</button>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -14,4 +14,9 @@ h1{color:var(--accent);margin:0 0 10px;}
   border:1px solid rgba(255,255,255,0.14);border-radius:10px;font-size:16px;text-align:center;}
 .feedback{margin-top:10px;font-size:13px;color:var(--muted);} 
 img, audio{max-width:100%;border-radius:8px;}
+.audio-wrap{display:flex;align-items:center;justify-content:center;gap:8px;margin-bottom:4px;}
+.audio-download{color:var(--muted);text-decoration:none;line-height:1;opacity:0.6;padding:6px;border-radius:8px;display:inline-flex;align-items:center;justify-content:center;transition:opacity 0.2s ease, background 0.2s ease;}
+.audio-download:focus,.audio-download:hover{opacity:1;background:rgba(255,255,255,0.08);}
+.audio-download svg{display:block;}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);border:0;}
 .small{font-size:12px;color:var(--muted);}


### PR DESCRIPTION
## Summary
- reintroduce a discreet download link next to the Puzzle 3 audio player so the file can be saved on mobile
- swap the text arrow for a compact SVG icon with assistive-only text for better accessibility
- refine the audio download styling to keep the control subtle while providing hover and focus feedback

## Testing
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e14e1973ac83229f527577b7089bf8